### PR TITLE
tune two - formatting and answer correctness tweaks

### DIFF
--- a/main.py
+++ b/main.py
@@ -18,7 +18,13 @@ model = "capybarahermes-2.5-mistral-7b.Q4_K_M.gguf"
 llm = Llama(model_path=f"models/{model}",verbose=False)
 
 prompt_tune = (
-        "Format your response using markup: use [bold]text[/bold], [italic]text[/italic], [colorname]text[/colorname] (e.g., [red]text[/red]), and other rich styles as appropriate to emphasize key points. Do not let formatting affect the correctness or meaning of your answer."
+    "Q: What is a pointer?\n"
+    "A: [bold]Pointer[/bold]: [italic]A variable that holds a memory address[/italic].\n\n"
+    "Q: How to print in Python?\n"
+    "A: [red]print(\"Hello\")[/red] – [italic]prints text to the console[/italic].\n\n"
+    "Q: What is a list?\n"
+    "A: [bold]List[/bold]: [green]An ordered, mutable collection[/green].\n\n"
+        "Format your response using markup: use [bold]text[/bold] for bold, [italic]text[/italic] for italics, [colorname]text[/colorname] (e.g., [red]text[/red]) for coloured text. Mimic the markup above. Ensure all markup is correct.\n"
         "Answer ONLY with the direct response. Do NOT add any notes, or explanations."
         "Always answer in two sentences or under 50 words. No extra explanation. No notes.\n"
         "Assume the user understands the general topic and needs a quick reminder. Freely use slang and jargon where necessary. ALWAYS answer the question.\n"

--- a/main.py
+++ b/main.py
@@ -1,4 +1,7 @@
 import sys
+from llama_cpp import Llama
+from rich import print
+
 prompt_input = sys.argv[1:]
 if not prompt_input:
     print("error: no prompt entered.")
@@ -9,22 +12,24 @@ if len(prompt_input) < 5:
     confirm_prompt = input("enter y/n: ")
     if confirm_prompt == "n": # doesn't explicitly need a y to continue
         exit() 
-from llama_cpp import Llama
+
 model = "capybarahermes-2.5-mistral-7b.Q4_K_M.gguf"
 
 llm = Llama(model_path=f"models/{model}",verbose=False)
 
 prompt_tune = (
-        "Answer ONLY with the direct response. Do NOT add any notes, or explanations. "
-        "Always answer in two sentences or under 50 words. No extra explanation. No notes. "
-        "Assume the user understands the general topic and needs a quick reminder. Freely use slang and jargon where necessary.\n"
+        "Format your response using markup: use [bold]text[/bold], [italic]text[/italic], [colorname]text[/colorname] (e.g., [red]text[/red]), and other rich styles as appropriate to emphasize key points. Do not let formatting affect the correctness or meaning of your answer."
+        "Answer ONLY with the direct response. Do NOT add any notes, or explanations."
+        "Always answer in two sentences or under 50 words. No extra explanation. No notes.\n"
+        "Assume the user understands the general topic and needs a quick reminder. Freely use slang and jargon where necessary. ALWAYS answer the question.\n"
+        "If the question refers to something that does not exist or is incorrect, say so. Do not answer untruthfully.\n"
         )
 res = llm.create_chat_completion(
         messages=[
             {"role": "user", "content": prompt_tune},
             {"role": "user", "content": prompt}
             ],
-        max_tokens=120,
+        max_tokens=300,
         temperature=0.2,
         top_p=0.9
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 llama-cpp-python
+rich


### PR DESCRIPTION
utilises prompts to allow the llm to use formatting available in the "rich" library.

note that explicitly mentioning the "python rich library" would sway the answers oddly. i needed to remove all direct references, and rely on examples.