### PR TITLE
updated build to work on system without gpu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,11 @@ compose-build:
 	TARGET=$(TARGET) ENABLE_CUDA=$(CUDA) CTX_LIMIT=$(CTX) docker compose build
 
 compose-up:
-	TARGET=$(TARGET) ENABLE_CUDA=$(CUDA) CTX_LIMIT=$(CTX) docker compose up
+ifeq ($(CUDA),ON)
+	TARGET=$(TARGET) ENABLE_CUDA=ON CTX_LIMIT=$(CTX) docker compose --profile gpu up
+else
+	TARGET=$(TARGET) ENABLE_CUDA=OFF CTX_LIMIT=$(CTX) docker compose --profile no-gpu up
+endif
 
 compose-down:
 	docker compose down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,24 +1,35 @@
-version: "3.9"
-
 services:
-  cpp-server:
+  cpp-server-cpu:
     build:
       context: .
       dockerfile: Dockerfile.server
       args:
-        ENABLE_CUDA: ${ENABLE_CUDA}
+        ENABLE_CUDA: "OFF"
     command: ./recall_server ${CTX_LIMIT}
     ports:
       - "8000:8000"
     volumes:
       - ./models:/app/models
       - ./data:/app/data
+    profiles: ["no-gpu"]
+  cpp-server-gpu:
+    build:
+      context: .
+      dockerfile: Dockerfile.server
+      args:
+        ENABLE_CUDA: "ON"
+    command: ./recall_server ${CTX_LIMIT}
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./models:/app/models
+      - ./data:/app/data
+    profiles: ["gpu"]
     deploy:
       resources:
         reservations:
           devices:
             - capabilities: [gpu]
-
   embed-service:
     build:
       context: .


### PR DESCRIPTION
made changes required for Recall to build on systems with no NVIDIA GPUs. Tested on Lenovo Thinkpad T480. System still works on my primary PC using both CPU and GPU.